### PR TITLE
Add templates for commit and PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,25 @@
+- Est-ce que mon code respecte les standards de qualité de mise en production de packages ?
+- Est-ce que la personne qui révise à toutes les informations pour valider les fonctionnalités / résolutions de problèmes sans trop de recherches ?
+- Est-ce que le client qui validera les tickets associés à les informations pour le faire sans perte de temps ?
+
+
+## Issues à faire valider pour fermer : 
+
+- [ ] issue #
+
+
+## Issues traitées à garder ouvertes ou en cours : 
+
+- [ ] issue #
+
+## Checklist:
+
+- [ ] Est-ce que le check du package passe en local ?
+- [ ] Est-ce que le CI passe ?
+- [ ] Est-ce que les fonctionnalités ajoutées / corrigées, sont documentées, testées ?
+- [ ] Est-ce que les fonctionnalités ajoutées / problèmes résolus sont brièvement présentées dans le message de la MR ?
+- [ ] Est-ce que les modifications sont liées à des tickets / issues que j'ai listés dans les commits et dans la MR elle-même ?
+- [ ] Est-ce que les tickets sont en mode "Révision" dans le Board de suivi du projet ?
+- [ ] Est-ce que chaque ticket, s'il doit être fermé après acceptation de la MR contient un commentaire qui dit comment le valider ?
+
+

--- a/.github/commit.template
+++ b/.github/commit.template
@@ -1,0 +1,17 @@
+# Define a direct explicite title
+# exemple: Create my_fun to build xml 
+
+Why?  
+
+-
+
+What?  
+
+-
+# 50-character subject line 
+# 72-character wrapped longer description.
+
+Issues
+# List corresponding issues 
+# example :Issue #12
+# Be careful with # as it will not be commit if line starts with #

--- a/dev/02_dev.R
+++ b/dev/02_dev.R
@@ -11,7 +11,7 @@
 #### CURRENT FILE: DEV SCRIPT #####
 ###################################
 
-# Engineering
+# Engineering ----
 
 # Hide files
 usethis::use_build_ignore("manifest.json")
@@ -21,6 +21,13 @@ usethis::use_build_ignore(".Renviron")
 usethis::use_git_ignore("data-raw/translation.Rmd")
 usethis::use_git_ignore("dev/translation.html")
 usethis::use_git_ignore("dev/data-docker/")
+
+## Git templates ----
+# copy system.file("gitlab", "template_commit", package = "thinkridentity")
+# in .github
+gert::git_config_set(
+  repo = ".", name = "commit.template", 
+  value = file.path(".github", "commit.template"))
 
 ## Dependencies ----
 ## Add one line by package you want to add as dependency


### PR DESCRIPTION
Why?

- Need for standardised commits and PR messages

What?

- Add templates in .github
- Update 02-dev for dev instructions

Issues

- issue #103