### PR TITLE
fix: allow new version of {renv}

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -8,40 +8,15 @@ if (file.exists(home_profile)) {
 }
 
 options(renv.config.pak.enabled = TRUE)
-
-# Fix CRAN version
-source("renv/activate.R")
-lock_ <- renv:::lockfile(file = "renv.lock")
-#
-if (grepl("ubuntu 18.04|debian 8", tolower(utils::osVersion))) {
-  repos <- c("RSPM" = "https://packagemanager.rstudio.com/all/__linux__/bionic/latest",
-  # repos <- c("RSPM" = "https://cran.rstudio.com",
-             "thinkropen" = "https://thinkr-open.r-universe.dev",
-             "CRAN" = "https://cran.rstudio.com")
-} else if (grepl("ubuntu 20.04|debian 9", tolower(utils::osVersion))) {
-  repos <- c("RSPM" = "https://packagemanager.rstudio.com/all/__linux__/focal/latest",
-  # repos <- c("RSPM" = "https://cran.rstudio.com",
-             "thinkropen" = "https://thinkr-open.r-universe.dev",
-             "CRAN" = "https://cran.rstudio.com")
-} else if (grepl("centos", tolower(utils::osVersion))) {
-  # Important for MacOS users in particular
-  repos <- c("RSPM" = "https://packagemanager.rstudio.com/all/__linux__/centos7/latest",
-             "thinkropen" = "https://thinkr-open.r-universe.dev",
-             "CRAN" = "https://cran.rstudio.com")
-} else {
-  # Important for MacOS users in particular
-  repos <- c("RSPM" = "https://cran.rstudio.com",
-             "thinkropen" = "https://thinkr-open.r-universe.dev",
-             "CRAN" = "https://cran.rstudio.com")
+if (dir.exists("renv")) {
+  source("renv/activate.R")
 }
 
-lock_$repos(.repos = repos)
-options(repos = repos)
+if (file.exists("~/.Rprofile")) {
+  source("~/.Rprofile")
+}
 
-
-lock_$write(file = "renv.lock")
-rm(lock_)
-rm(repos)
+source("dev/switch_renv_repo.R")
 
 
 renv::activate()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM rocker/geospatial:4.3.0
 RUN apt-get update && apt-get install -y  gdal-bin git-core libcairo2-dev libcurl4-openssl-dev libgdal-dev libgeos-dev libgeos++-dev libgit2-dev libicu-dev libpng-dev libpq-dev libproj-dev libssl-dev libudunits2-dev libxml2-dev make pandoc pandoc-citeproc zlib1g-dev && rm -rf /var/lib/apt/lists/*
+
 # RUN echo "options(renv.config.pak.enabled = TRUE, repos = c(CRAN = 'https://packagemanager.rstudio.com/all/__linux__/focal/latest'), download.file.method = 'libcurl', Ncpus = 4)" >> /usr/local/lib/R/etc/Rprofile.site
-RUN mkdir -p /usr/local/lib/R/etc
+# RUN mkdir -p /usr/local/lib/R/etc
 RUN echo "options(repos = c(CRAN = 'https://packagemanager.rstudio.com/all/__linux__/focal/latest'), download.file.method = 'libcurl', Ncpus = 4)" >> /usr/local/lib/R/etc/Rprofile.site
 RUN echo "options(warn = 2);Sys.setenv(RENV_PATHS_CACHE='~/cache')" >> $R_HOME/etc/Rprofile.site
 

--- a/dev/switch_renv_repo.R
+++ b/dev/switch_renv_repo.R
@@ -1,15 +1,56 @@
 if (file.exists("~/.Rprofile")) {
-    source("~/.Rprofile")
+  source("~/.Rprofile")
 }
 if (Sys.info()["user"] != "rstudio-connect") {
-    lock_ <- renv:::lockfile(file = "renv.lock")
-    # # Fix CRAN version
-    if (Sys.info()["sysname"] == "Linux") {
-        cat("[renv] Setting repo to RSPM ----\n")
-        lock_$repos(CRAN = "https://packagemanager.rstudio.com/all/__linux__/focal/latest")
-    } else {
-        cat("[renv] Setting repo to cran.rstudio.com ----\n")
-        lock_$repos(CRAN = "https://cran.rstudio.com")
-    }
+  # Fix CRAN version
+  
+  if (grepl("ubuntu 18.04|debian 8", tolower(utils::osVersion))) {
+    cat("[renv] Setting repo to RSPM bionic ----\n")
+    repos <- c("RSPM" = "https://packagemanager.rstudio.com/all/__linux__/bionic/latest",
+               # repos <- c("RSPM" = "https://cran.rstudio.com",
+               # "thinkropen" = "https://thinkr-open.r-universe.dev",
+               "CRAN" = "https://cran.rstudio.com")
+  } else if (grepl("ubuntu 20.04|debian 9", tolower(utils::osVersion))) {
+    cat("[renv] Setting repo to RSPM focal ----\n")
+    repos <- c("RSPM" = "https://packagemanager.rstudio.com/all/__linux__/focal/latest",
+               # repos <- c("RSPM" = "https://cran.rstudio.com",
+               # "thinkropen" = "https://thinkr-open.r-universe.dev",
+               "CRAN" = "https://cran.rstudio.com")
+  } else if (grepl("ubuntu 22.04|debian 10", tolower(utils::osVersion))) {
+    cat("[renv] Setting repo to RSPM jammy ----\n")
+    repos <- c("RSPM" = "https://packagemanager.rstudio.com/all/__linux__/jammy/latest",
+               # repos <- c("RSPM" = "https://cran.rstudio.com",
+               # "thinkropen" = "https://thinkr-open.r-universe.dev",
+               "CRAN" = "https://cran.rstudio.com")
+  } else if (grepl("centos", tolower(utils::osVersion))) {
+    cat("[renv] Setting repo to RSPM centos ----\n")
+    # Important for MacOS users in particular
+    repos <- c("RSPM" = "https://packagemanager.rstudio.com/all/__linux__/centos7/latest",
+               # "thinkropen" = "https://thinkr-open.r-universe.dev",
+               "CRAN" = "https://cran.rstudio.com")
+  } else {
+    # Important for MacOS users in particular
+    repos <- c("RSPM" = "https://cran.rstudio.com",
+               # "thinkropen" = "https://thinkr-open.r-universe.dev",
+               "CRAN" = "https://cran.rstudio.com")
+  }
+  
+  a <- try(lock_ <- renv:::lockfile(file = "renv.lock"), silent = TRUE)
+  if (!inherits(a, "try-error")) {
+    lock_$repos(.repos = repos)
     lock_$write(file = "renv.lock")
+    rm(lock_)
+  } else {
+    # renv::lockfile_modify(repos = c(repos))
+    lock_ <- readLines("renv.lock")
+    which_url <- grep("URL", lock_)
+    lock_[which_url] <- sprintf("        \"URL\": \"%s\"", repos[seq_along(which_url)])
+    cat(lock_, sep = "\n", file = "renv.lock")
+    rm(lock_)
+  }
+  options(repos = repos)
+  
+  
+  
+  rm(repos)
 }

--- a/renv.lock
+++ b/renv.lock
@@ -7,10 +7,6 @@
         "URL": "https://packagemanager.rstudio.com/all/latest"
       },
       {
-        "Name": "thinkropen",
-        "URL": "https://thinkr-open.r-universe.dev"
-      },
-      {
         "Name": "CRAN",
         "URL": "https://cran.rstudio.com"
       }


### PR DESCRIPTION
New version of {renv} on GitHub does not use renv:::lockfile() anymore.
A workaround with readLines() + cat() is needed to change the repos as renv::lockfile_modify() is not operationnal for the moment
